### PR TITLE
Default product data to '' so that it's not saved to DB as 'undefined'

### DIFF
--- a/app/routes/app.qrcodes.$id.jsx
+++ b/app/routes/app.qrcodes.$id.jsx
@@ -121,9 +121,9 @@ export default function QRCodeForm() {
   function handleSave() {
     const data = {
       title: formState.title,
-      productId: formState.productId,
-      productVariantId: formState.productVariantId,
-      productHandle: formState.productHandle,
+      productId: formState.productId || "",
+      productVariantId: formState.productVariantId || "",
+      productHandle: formState.productHandle || "",
       destination: formState.destination,
     };
 


### PR DESCRIPTION
Fix an issues where:

1. Enter a title but do not select a product
2. Click save.
3. Product fields are saved to the database as "undefined".
4. `supplementQRCode` uses `"undefined"` as product page.

To test, follow these steps before and after this commit.