### PR TITLE
Prevent errors when product returns null

### DIFF
--- a/app/models/QRCode.server.js
+++ b/app/models/QRCode.server.js
@@ -82,10 +82,10 @@ async function supplementQRCode(QRCode, graphql) {
 
   return {
     ...QRCode,
-    productDeleted: !product.title,
-    productTitle: product.title,
-    productImage: product.images?.nodes[0]?.url,
-    productAlt: product.images?.nodes[0]?.altText,
+    productDeleted: !product?.title,
+    productTitle: product?.title,
+    productImage: product?.images?.nodes[0]?.url,
+    productAlt: product?.images?.nodes[0]?.altText,
     destinationUrl: getDestinationUrl(QRCode),
     image: await getQRCodeImage(QRCode.id),
   };

--- a/app/routes/app._index.jsx
+++ b/app/routes/app._index.jsx
@@ -33,6 +33,7 @@ export default function Index() {
   const navigate = useNavigate();
 
   function truncate(str) {
+    if (!str) return;
     const n = 25;
     return str.length > n ? str.substr(0, n - 1) + "…" : str;
   }

--- a/app/routes/app._index.jsx
+++ b/app/routes/app._index.jsx
@@ -98,13 +98,11 @@ export default function Index() {
                 {/* [START deleted] */}
                 {productDeleted ? (
                   <HorizontalStack align="start" gap={"2"}>
-                    <Tooltip content="product has been deleted">
-                      <span style={{ width: "20px" }}>
-                        <Icon source={DiamondAlertMajor} color="critical" />
-                      </span>
-                    </Tooltip>
-                    <Text color={productDeleted && "critical"} as="span">
-                      {truncate(productTitle)}
+                    <span style={{ width: "20px" }}>
+                      <Icon source={DiamondAlertMajor} color="critical" />
+                    </span>
+                    <Text color={"critical"} as="span">
+                      product has been deleted
                     </Text>
                   </HorizontalStack>
                 ) : (


### PR DESCRIPTION
When a product is deleted, you currently get an error:
 
<img width="1461" alt="Screenshot 2023-07-27 at 3 09 32 PM" src="https://github.com/Shopify/example-app--qr-code--remix/assets/85357687/1921012f-346a-40e1-bd94-33a759cbf78a">

The changes in this PR make it so you instead make it to the intended error state on your index screen:

![Screenshot 2023-07-27 at 3 07 57 PM](https://github.com/Shopify/example-app--qr-code--remix/assets/85357687/c90c2f86-de6d-42be-baac-b6cb562ddbed)