### PR TITLE
Simplify construction of URL

### DIFF
--- a/app/models/QRCode.server.js
+++ b/app/models/QRCode.server.js
@@ -30,9 +30,8 @@ export async function getQRCodes(shop, graphql) {
 
 // [START get-qrcode-image]
 export async function getQRCodeImage(id) {
-  const { origin } = new URL(process.env.SHOPIFY_APP_URL);
-
-  const image = await qrcode.toBuffer(`${origin}/qrcodes/${id}/scan`);
+  const url = new URL(`/qrcodes/${id}/scan`, process.env.SHOPIFY_APP_URL);
+  const image = await qrcode.toBuffer(url.href);
 
   return `data:image/jpeg;base64, ${image.toString("base64")}`;
 }


### PR DESCRIPTION
Rather than creating a `URL` just to extract the origin, then create a URL string using interpolation, you can use `process.env.SHOPIFY_APP_URL` as the base URL and create a relative URL from it.