### PR TITLE
Use instance-style naming for instances

### DIFF
--- a/app/models/QRCode.server.js
+++ b/app/models/QRCode.server.js
@@ -3,27 +3,27 @@ import db from "../db.server";
 
 // [START get-qrcode]
 export async function getQRCode(id, graphql) {
-  const QRCode = await db.qRCode.findFirst({ where: { id } });
+  const qrCode = await db.qRCode.findFirst({ where: { id } });
 
-  if (!QRCode) {
+  if (!qrCode) {
     return null;
   }
 
-  return supplementQRCode(QRCode, graphql);
+  return supplementQRCode(qrCode, graphql);
 }
 
 export async function getQRCodes(shop, graphql) {
-  const QRCodes = await db.qRCode.findMany({
+  const qrCodes = await db.qRCode.findMany({
     where: { shop },
     orderBy: { id: "desc" },
   });
 
-  if (!QRCodes.length) {
-    return QRCodes;
+  if (!qrCodes.length) {
+    return qrCodes;
   }
 
   return Promise.all(
-    QRCodes.map(async (QRCode) => supplementQRCode(QRCode, graphql))
+    qrCodes.map(async (qrCode) => supplementQRCode(qrCode, graphql))
   );
 }
 // [END get-qrcode]
@@ -39,22 +39,22 @@ export async function getQRCodeImage(id) {
 // [END get-qrcode-image]
 
 // [START get-destination]
-export function getDestinationUrl(QRCode) {
-  if (QRCode.destination === "product") {
-    return `https://${QRCode.shop}/products/${QRCode.productHandle}`;
+export function getDestinationUrl(qrCode) {
+  if (qrCode.destination === "product") {
+    return `https://${qrCode.shop}/products/${qrCode.productHandle}`;
   }
 
-  const id = QRCode.productVariantId.replace(
+  const id = qrCode.productVariantId.replace(
     /gid:\/\/shopify\/ProductVariant\/([0-9]+)/,
     "$1"
   );
 
-  return `https://${QRCode.shop}/cart/${id}:1`;
+  return `https://${qrCode.shop}/cart/${id}:1`;
 }
 // [END get-destination]
 
 // [START hydrate-qrcode]
-async function supplementQRCode(QRCode, graphql) {
+async function supplementQRCode(qrCode, graphql) {
   const response = await graphql(
     `
       query supplementQRCode($id: ID!) {
@@ -71,7 +71,7 @@ async function supplementQRCode(QRCode, graphql) {
     `,
     {
       variables: {
-        id: QRCode.productId,
+        id: qrCode.productId,
       },
     }
   );
@@ -81,13 +81,13 @@ async function supplementQRCode(QRCode, graphql) {
   } = await response.json();
 
   return {
-    ...QRCode,
+    ...qrCode,
     productDeleted: !product?.title,
     productTitle: product?.title,
     productImage: product?.images?.nodes[0]?.url,
     productAlt: product?.images?.nodes[0]?.altText,
-    destinationUrl: getDestinationUrl(QRCode),
-    image: await getQRCodeImage(QRCode.id),
+    destinationUrl: getDestinationUrl(qrCode),
+    image: await getQRCodeImage(qrCode.id),
   };
 }
 // [END hydrate-qrcode]

--- a/app/routes/app.qrcodes.$id.jsx
+++ b/app/routes/app.qrcodes.$id.jsx
@@ -69,12 +69,12 @@ export async function action({ request, params }) {
     return json({ errors }, { status: 422 });
   }
 
-  const QRCode =
+  const qrCode =
     params.id === "new"
       ? await db.qRCode.create({ data })
       : await db.qRCode.update({ where: { id: Number(params.id) }, data });
 
-  return redirect(`/app/qrcodes/${QRCode.id}`);
+  return redirect(`/app/qrcodes/${qrCode.id}`);
 }
 // [END action]
 
@@ -82,9 +82,9 @@ export async function action({ request, params }) {
 export default function QRCodeForm() {
   const errors = useActionData()?.errors || {};
 
-  const QRCode = useLoaderData();
-  const [formState, setFormState] = useState(QRCode);
-  const [cleanFormState, setCleanFormState] = useState(QRCode);
+  const qrCode = useLoaderData();
+  const [formState, setFormState] = useState(qrCode);
+  const [cleanFormState, setCleanFormState] = useState(qrCode);
   const isDirty = JSON.stringify(formState) !== JSON.stringify(cleanFormState);
 
   const nav = useNavigation();
@@ -137,7 +137,7 @@ export default function QRCodeForm() {
   return (
     <Page>
       {/* [START breadcrumbs] */}
-      <ui-title-bar title={QRCode.id ? "Edit QR code" : "Create new QR code"}>
+      <ui-title-bar title={qrCode.id ? "Edit QR code" : "Create new QR code"}>
         <button variant="breadcrumb" onClick={() => navigate("/app")}>
           QR codes
         </button>
@@ -231,8 +231,8 @@ export default function QRCodeForm() {
                     }
                     error={errors.destination}
                   />
-                  {QRCode.destinationUrl ? (
-                    <Button plain url={QRCode.destinationUrl} external>
+                  {qrCode.destinationUrl ? (
+                    <Button plain url={qrCode.destinationUrl} external>
                       Go to destination URL
                     </Button>
                   ) : null}
@@ -248,8 +248,8 @@ export default function QRCodeForm() {
             <Text as={"h2"} variant="headingLg">
               QR code
             </Text>
-            {QRCode ? (
-              <EmptyState image={QRCode.image} imageContained={true} />
+            {qrCode ? (
+              <EmptyState image={qrCode.image} imageContained={true} />
             ) : (
               <EmptyState image="">
                 Your QR code will appear here after you save
@@ -257,16 +257,16 @@ export default function QRCodeForm() {
             )}
             <VerticalStack gap="3">
               <Button
-                disabled={!QRCode?.image}
-                url={QRCode?.image}
+                disabled={!qrCode?.image}
+                url={qrCode?.image}
                 download
                 primary
               >
                 Download
               </Button>
               <Button
-                disabled={!QRCode.id}
-                url={`/qrcodes/${QRCode.id}`}
+                disabled={!qrCode.id}
+                url={`/qrcodes/${qrCode.id}`}
                 external
               >
                 Go to public URL
@@ -282,7 +282,7 @@ export default function QRCodeForm() {
               {
                 content: "Delete",
                 loading: isDeleting,
-                disabled: !QRCode.id || !QRCode || isSaving || isDeleting,
+                disabled: !qrCode.id || !qrCode || isSaving || isDeleting,
                 destructive: true,
                 outline: true,
                 onAction: () => submit({}, { method: "delete" }),


### PR DESCRIPTION
Maybe this is a convention with Prisma, but I couldn't find it in their docs.

Typically, variables starting with uppercase indicate a class or component, whereas these are instances as far as I can tell.