### PR TITLE
Use newest Polaris icons

### DIFF
--- a/app/routes/app._index.jsx
+++ b/app/routes/app._index.jsx
@@ -14,7 +14,7 @@ import {
 } from "@shopify/polaris";
 
 import { getQRCodes } from "../models/QRCode.server";
-import { DiamondAlertMajor, ImageMajor } from "@shopify/polaris-icons";
+import { AlertDiamondIcon, ImageIcon } from "@shopify/polaris-icons";
 
 // [START loader]
 export async function loader({ request }) {
@@ -77,7 +77,7 @@ const QRTableRow = ({ qrCode }) => (
   <IndexTable.Row id={qrCode.id} position={qrCode.id}>
     <IndexTable.Cell>
       <Thumbnail
-        source={qrCode.productImage || ImageMajor}
+        source={qrCode.productImage || ImageIcon}
         alt={qrCode.productTitle}
         size="small"
       />
@@ -90,7 +90,7 @@ const QRTableRow = ({ qrCode }) => (
       {qrCode.productDeleted ? (
         <InlineStack align="start" gap="200">
           <span style={{ width: "20px" }}>
-            <Icon source={DiamondAlertMajor} tone="critical" />
+            <Icon source={AlertDiamondIcon} tone="critical" />
           </span>
           <Text tone="critical" as="span">
             product has been deleted

--- a/app/routes/app.qrcodes.$id.jsx
+++ b/app/routes/app.qrcodes.$id.jsx
@@ -25,7 +25,7 @@ import {
   BlockStack,
   PageActions,
 } from "@shopify/polaris";
-import { ImageMajor } from "@shopify/polaris-icons";
+import { ImageIcon } from "@shopify/polaris-icons";
 
 import db from "../db.server";
 import { getQRCode, validateQRCode } from "../models/QRCode.server";
@@ -183,7 +183,7 @@ export default function QRCodeForm() {
                 {formState.productId ? (
                   <InlineStack blockAlign="center" gap="500">
                     <Thumbnail
-                      source={formState.productImage || ImageMajor}
+                      source={formState.productImage || ImageIcon}
                       alt={formState.productAlt}
                     />
                     <Text as="span" variant="headingMd" fontWeight="semibold">

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@shopify/app-bridge-types": "^0.0.3",
     "@shopify/cli": "^3.48",
     "@shopify/polaris": "^12.0.0",
+    "@shopify/polaris-icons": "^8.0.0",
     "@shopify/shopify-api": "^9.0.2",
     "@shopify/shopify-app-remix": "^2.4.0",
     "@shopify/shopify-app-session-storage-prisma": "^3.0.0",


### PR DESCRIPTION
When devs were attempting to run the app, it was erroring out because we were using old Polaris icons.

Updated the references to `DiamondAlertMajor` and `ImageMajor` to `AlertDiamondIcon` and `ImageIcon` respectively
Pinned to a polaris icons version for future

tested, icons appear as expected

![image](https://github.com/Shopify/example-app--qr-code--remix/assets/58563081/603b2fc8-88ae-45a1-9ae0-ae975edf18ac)

based on this fork (thank you!): https://github.com/Shopify/example-app--qr-code--remix/pull/16
