### PR TITLE
Tweak import syntax for `getQRCodeImage`

### DIFF
--- a/app/routes/qrcodes.$id.jsx
+++ b/app/routes/qrcodes.$id.jsx
@@ -3,7 +3,7 @@ import invariant from "tiny-invariant";
 import { useLoaderData } from "@remix-run/react";
 
 import db from "../db.server";
-import { getQRCodeImage } from "~/models/QRCode.server";
+import { getQRCodeImage } from "../models/QRCode.server";
 
 // [START loader]
 export const loader = async ({ params }) => {


### PR DESCRIPTION
update `getQRCodeImage` import to use `../` syntax for the path instead of `../`

installed and tested, QR code is retrieved as expected

<img width="1088" alt="image" src="https://github.com/Shopify/example-app--qr-code--remix/assets/58563081/23527f40-4116-46ef-928b-6b251f69009d">
