### PR TITLE
QRCode.server.js to using deprecated query

### DIFF
--- a/app/models/QRCode.server.js
+++ b/app/models/QRCode.server.js
@@ -56,10 +56,14 @@ async function supplementQRCode(qrCode, graphql) {
       query supplementQRCode($id: ID!) {
         product(id: $id) {
           title
-          images(first: 1) {
+          media(first: 1) {
             nodes {
-              altText
-              url
+              preview {
+                image {
+                  altText
+                  url
+                }
+              }
             }
           }
         }
@@ -80,8 +84,8 @@ async function supplementQRCode(qrCode, graphql) {
     ...qrCode,
     productDeleted: !product?.title,
     productTitle: product?.title,
-    productImage: product?.images?.nodes[0]?.url,
-    productAlt: product?.images?.nodes[0]?.altText,
+    productImage: product?.media?.nodes[0]?.preview?.image?.url,
+    productAlt: product?.media?.nodes[0]?.preview?.image?.altText,
     destinationUrl: getDestinationUrl(qrCode),
     image: await qrCodeImagePromise,
   };


### PR DESCRIPTION
Closes https://github.com/Shopify/example-app--qr-code--remix/issues/29
Closes https://github.com/Shopify/shopify-dev/issues/59016

Second issue came into `shopify-dev`. Tested locally, behavior unchanged.