### PR TITLE
Update app-bridge usage

### DIFF
--- a/app/routes/app._index.jsx
+++ b/app/routes/app._index.jsx
@@ -121,12 +121,10 @@ export default function Index() {
 
   // [START page]
   return (
-    <s-page>
-      <ui-title-bar title="QR codes">
-        <Link variant="primary" to="/app/qrcodes/new">
-          Create QR code
-        </Link>
-      </ui-title-bar>
+    <s-page heading="QR codes">
+      <s-link slot="secondary-actions" href="/app/qrcodes/new">
+        Create QR code
+      </s-link>
       {qrCodes.length === 0 ? (
         <EmptyQRCodeState />
       ) : (

--- a/app/routes/app.qrcodes.$id.jsx
+++ b/app/routes/app.qrcodes.$id.jsx
@@ -159,30 +159,20 @@ export default function QRCodeForm() {
 
   return (
     <>
-      <ui-save-bar id="qr-code-form">
-        <button onClick={handleReset} disabled={isSaving}>
-          Discard
-        </button>
-        <button onClick={handleSave} disabled={isSaving} variant="primary">
-          Save
-        </button>
-      </ui-save-bar>
-      {/* [END save-bar] */}
-      {/* [START breadcrumbs] */}
-      <ui-title-bar title={initialFormState.title || "Create QR code"}>
-        <Link
-          to="/app"
-          variant="breadcrumb"
-          onClick={(e) => (isDirty ? e.preventDefault() : navigate("/app/"))}
-        >
-          QR Codes
-        </Link>
-        {initialFormState.id && <button onClick={handleDelete}>Delete</button>}
-      </ui-title-bar>
-      {/* [END breadcrumbs] */}
-      <form>
+      <form data-save-bar onSubmit={handleSave} onReset={handleReset}>
         {/* [START polaris] */}
-        <s-page>
+        <s-page heading={initialFormState.title || "Create QR code"}>
+          {/* [START breadcrumbs] */}
+          <s-link
+            href="/app"
+            slot="breadcrumb-actions"
+            onClick={(e) => (isDirty ? e.preventDefault() : navigate("/app/"))}
+          >
+          {/* [END breadcrumbs] */}
+            QR Codes
+          </s-link>
+          {initialFormState.id &&
+            <s-button slot="secondary-actions" onClick={handleDelete}>Delete</s-button>}
           <s-section heading="QR Code information">
             <s-stack gap="base">
               {/* [START title] */}


### PR DESCRIPTION
This pull request updates the UI components for the QR code pages to use the new custom `s-*` component library instead of the previous `ui-*` and `Link` components. The changes modernize the look and structure of both the main QR codes listing page and the QR code form page, improving consistency and maintainability.

**UI component migration and improvements:**

* Replaced `ui-title-bar` and `Link` with `s-page` and `s-link` components in the QR codes listing page, moving the "Create QR code" action to a secondary slot for better alignment with the new design system.
* Refactored the QR code form page to use a `form` element with `data-save-bar`, and replaced `ui-save-bar`, `ui-title-bar`, and `Link` with `s-page`, `s-link`, and `s-button` components. The "Delete" action is now a secondary action button, and the breadcrumb uses the new slot-based approach.